### PR TITLE
Implement activation registry (closes #17)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["lib"]
 
 [dependencies]
 env_logger = "*"
+generic_singleton = "*"
 log = "*"
 ndarray = { version = "0.15.6", features = ["serde"] }
 num-traits = "*"

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -1,12 +1,17 @@
 //! Definition of the [`Activation`] struct and the most common activation functions as well as their
 //! derivatives.
 
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use generic_singleton::get_or_init;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::component::TensorComponent;
 use crate::tensor::TensorBase;
 
 
+type ActivationRegistry<T> = HashMap<String, Activation<T>>;
 type TFunc<T> = fn(&T) -> T;
 
 
@@ -26,27 +31,9 @@ pub struct Activation<T: TensorBase> {
 
 /// Methods for convenient construction and calling.
 impl<T: TensorBase> Activation<T> {
-    /// Basic constructor to manually define all fields.
+    /// Basic constructor.
     pub fn new<S: Into<String>>(name: S, function: TFunc<T>, derivative: TFunc<T>) -> Self {
-        Self { name: name.into(), function, derivative }
-    }
-
-    /// Convenience constructor for known/available activation functions.
-    ///
-    /// Pre-defined functions are determined from hard-coded names:
-    /// - [`sigmoid`]
-    /// - [`relu`]
-    pub fn from_name<S: Into<String>>(name: S) -> Self {
         let name: String = name.into();
-        let function: TFunc<T>;
-        let derivative: TFunc<T>;
-        if name == "sigmoid" {
-            (function, derivative) = (sigmoid, sigmoid_prime);
-        } else if name == "relu" {
-            (function, derivative) = (relu, relu_prime);
-        } else {
-            panic!();
-        }
         Self { name, function, derivative }
     }
 
@@ -62,6 +49,100 @@ impl<T: TensorBase> Activation<T> {
 }
 
 
+/// Associated functions for registering and retrieving activation functions.
+///
+/// The activation registry is a singleton.
+/// It is static from the moment of initalization and generic over the [`TensorBase`] type.
+///
+/// # Implementation detail
+/// Under the hood the activation registry uses the **[`generic_singleton`]** crate
+/// to initialize and access a [`HashMap`] with the names as [`String`] keys and [`Activation`] values.
+///
+/// [`generic_singleton`]: https://docs.rs/generic_singleton/latest/generic_singleton/
+impl<T: TensorBase + 'static> Activation<T> {
+    /// Gets a static reference to the activation registry singleton.
+    /// The registry is wrapped in a [`RwLock`].
+    ///
+    /// When called for the first time, the activation registry is initialized first.
+    fn get_activation_registry() -> &'static RwLock<ActivationRegistry<T>> {
+        get_or_init!(|| RwLock::new(ActivationRegistry::<T>::new()))
+    }
+
+    /// Creates and registers a new [`Activation`].
+    ///
+    /// A clone of the newly created [`Activation`] is added to the activation registry.
+    /// Subsequent calls to [`Activation::from_name`] passing the same name will return a clone of it.
+    ///
+    /// # Arguments:
+    /// - `name` - Key under which to register the new activation;
+    ///            also passed on to the [`Activation::new`] constructor.
+    /// - `function` - Passed on to the [`Activation::new`] constructor.
+    /// - `derivative` - Passed on to the [`Activation::new`] constructor.
+    ///
+    /// # Returns
+    /// Clone of the newly created [`Activation`] with the specified parameters.
+    pub fn register<S: Into<String>>(name: S, function: TFunc<T>, derivative: TFunc<T>) -> Self {
+        let name: String = name.into();
+        let registry_lock = Self::get_activation_registry();
+        if registry_lock.read().unwrap().contains_key(&name) {
+            // TODO: Instead of panicking, make this function return a `Result`.
+            panic!("Activation already registered: {}", name);
+        }
+        let new_activation = Activation::<T>::new(name.clone(), function, derivative);
+        registry_lock.write().unwrap().insert(name, new_activation.clone());
+        new_activation
+    }
+
+    /// Returns a clone of a previously registered [`Activation`] by name.
+    ///
+    /// Unless custom instances were added before via [`Activation::register`], reference implementations
+    /// for the following activation functions will be available by default:
+    /// - `sigmoid`
+    /// - `relu`
+    ///
+    /// # Arguments
+    /// - `name` - The name/key of the activation to return.
+    ///
+    /// # Returns
+    /// Clone of the [`Activation`] instance with the specified `name`.
+    pub fn from_name<S: Into<String>>(name: S) -> Self {
+        let name: String = name.into();
+        let registry_lock = Self::get_activation_registry();
+        // The registry should only be empty the first time this method is called.
+        // In that case, fill it with the known/common activation functions.
+        if registry_lock.read().unwrap().is_empty() {
+            Self::register_common(registry_lock)
+        }
+        if !registry_lock.read().unwrap().contains_key(&name) {
+            // TODO: Instead of panicking, make this function return a `Result`.
+            panic!("No such key registered: {}", name)
+        }
+        registry_lock.read().unwrap().get(&name).unwrap().clone()
+    }
+
+    /// Registers reference implementations of some common activation functions.
+    ///
+    /// Activation functions that will be available by name after calling this method:
+    /// - `sigmoid`
+    /// - `relu`
+    ///
+    /// # Arguments
+    /// - `registry_lock` - Reference to the activation registry wrapped in a [`RwLock`]
+    fn register_common(registry_lock: &RwLock<ActivationRegistry<T>>) {
+        // TODO: Consider using `HashMap::try_insert` instead to avoid overwriting any custom
+        //       implementations of common activation functions.
+        registry_lock.write().unwrap().insert(
+            "sigmoid".to_owned(),
+            Activation::<T>::new("sigmoid".to_owned(), sigmoid, sigmoid_prime),
+        );
+        registry_lock.write().unwrap().insert(
+            "relu".to_owned(),
+            Activation::<T>::new("relu".to_owned(), relu, relu_prime),
+        );
+    }
+}
+
+
 /// Allows [`serde`] to serialize [`Activation`] objects.
 impl<T: TensorBase> Serialize for Activation<T> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -71,9 +152,9 @@ impl<T: TensorBase> Serialize for Activation<T> {
 
 
 /// Allows [`serde`] to deserialize to [`Activation`] objects.
-impl<'de, T: TensorBase> Deserialize<'de> for Activation<T> {
+impl<'de, T: TensorBase + 'static> Deserialize<'de> for Activation<T> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(Self::from_name(String::deserialize(deserializer)?))
+        Ok(Activation::from_name(String::deserialize(deserializer)?))
     }
 }
 
@@ -156,15 +237,20 @@ mod tests {
         use super::*;
 
         #[test]
-        fn test_from_name() {
+        fn test_register_and_from_name() {
             use ndarray::Array2;
 
-            let activation: Activation<Array2<f64>> = Activation::from_name("relu");
-            let expected_activation = Activation {
-                name: "relu".to_owned(),
-                function: relu,
-                derivative: relu_prime
-            };
+            let name = "foo".to_owned();
+            let function = relu;
+            let derivative = relu_prime;
+
+            // Register:
+            let activation = Activation::<Array2<f64>>::register(name.clone(), function, derivative);
+            let expected_activation = Activation { name, function, derivative };
+            assert_eq!(activation, expected_activation);
+
+            // Get from registry by name:
+            let activation = Activation::from_name("foo");
             assert_eq!(activation, expected_activation);
         }
 

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -35,23 +35,5 @@ mod tests {
 
     #[test]
     fn test() {
-        let input = array![
-            [1.],
-            [1.],
-        ];
-        let layer = Layer{
-            weights: array![
-                [1., 0.],
-                [0., 1.],
-            ],
-            biases: array![
-                [-1.],
-                [-1.],
-            ],
-            activation: Activation::from_name("sigmoid"),
-        };
-        let (z, a) = layer.feed_forward(&input);
-        println!("{}", z);
-        println!("{}", a);
     }    
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Rust library for creating, training and evolving neural networks.
 
-#![feature(iter_array_chunks, trait_alias)]
+#![feature(iter_array_chunks, map_try_insert, trait_alias)]
 
 pub mod activation;
 pub mod component;

--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -143,8 +143,8 @@ where
         Sub<Self, Output = Self>;
 
 
-/// [`TensorBase`] combined with `serde` (de-)serialization.
-pub trait TensorSerde = TensorBase + DeserializeOwned + Serialize;
+/// Owned [`TensorBase`] combined with `serde` (de-)serialization.
+pub trait TensorSerde = 'static + TensorBase + DeserializeOwned + Serialize;
 
 
 /// [`TensorOp`] and [`TensorSerde`].

--- a/tests/test_sgd.rs
+++ b/tests/test_sgd.rs
@@ -18,7 +18,7 @@ fn test_sgd() {
                     [0.],
                     [0.],
                 ],
-                activation: Activation::from_name("relu"),
+                activation: Activation::from_name("relu").unwrap(),
             },
             Layer{
                 weights: array![
@@ -29,7 +29,7 @@ fn test_sgd() {
                     [0.],
                     [0.],
                 ],
-                activation: Activation::from_name("relu"),
+                activation: Activation::from_name("relu").unwrap(),
             },
         ],
         CostFunction::<Array2<f64>>::from_name("quadratic"),


### PR DESCRIPTION
As described in #17, this adds the ability for the user to register his own activation functions and have them (de-)serialized properly.

The interface is comprised of two associated functions for the `Activation` struct:
- `register`  takes a name, a pointer to the actual activation function and a pointer to the derivative function (just like the `new` constructor), creates a new `Activation` with those and inserts it into the registry. If an instance with the same name was already present, it is replaced and the old one is returned (wrapped in `Some(...)`). Otherwise `None` is returned. https://github.com/mfajnberg/tensorevo/blob/4895317df5432894ff2b88b117c7a50144d31626/src/activation.rs#L108-L113
- `from_name` now returns a clone of the `Activation` instance registered under the provided name (wrapped in `Some(...)`). If none was registered under that name, `None` is returned. Since [`from_name` used to return an `Activation`](https://github.com/mfajnberg/tensorevo/blob/56188d2f82f653887d29254d5e9e167673ccec16/src/activation.rs#L39) proper, this is technically a breaking change. https://github.com/mfajnberg/tensorevo/blob/4895317df5432894ff2b88b117c7a50144d31626/src/activation.rs#L131-L136

The implementation relies on the [`generic_singleton::get_or_init`](https://docs.rs/generic_singleton/latest/generic_singleton/macro.get_or_init.html) macro and the registry (for a specific type `Activation<T>`) is a static singleton. The `ActivationRegistry<T>` is simply a type alias for `HashMap<String, Activation<T>>`.
https://github.com/mfajnberg/tensorevo/blob/4895317df5432894ff2b88b117c7a50144d31626/src/activation.rs#L67-L73

During initialization of the registry singleton, the pre-implemented common activation functions (currently only `sigmoid` and `relu`) are added automatically. Those are then available by default, but can be replaced by custom implementations via `register` at any point.
https://github.com/mfajnberg/tensorevo/blob/4895317df5432894ff2b88b117c7a50144d31626/src/activation.rs#L79-L89

There is still a lot of `unwrap`ping going on there with the `RwLock`, but since we have not cleaned that up anywhere else in the code yet, I did not bother to handle potential errors more cleanly yet.