### PR TITLE
Add `Registered` trait as abstraction for activation and cost function registry

### DIFF
--- a/src/activation.rs
+++ b/src/activation.rs
@@ -15,12 +15,12 @@ pub use self::functions::*;
 type TFunc<T> = fn(&T) -> T;
 
 
-/// Convenience struct to store an activation function together with its name and derivative.
+/// Contains a named activation function together with its derivative.
 ///
-/// This is used in the [`Layer`] struct.
-/// Facilitates (de-)serialization.
+/// Used primarily in the [`Layer`] struct.
 ///
-/// See the **`Registerd`** trait implementation below for a usage example.
+/// See the [**`Registerd`** trait implementation](#impl-Registered<String>-for-Activation<T>)
+/// below for a more general usage example.
 ///
 /// [`Layer`]: crate::layer::Layer
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -31,9 +31,18 @@ pub struct Activation<T: TensorBase> {
 }
 
 
-/// Methods for convenient construction and calling.
+/// Methods for construction and calling.
 impl<T: TensorBase> Activation<T> {
     /// Basic constructor.
+    ///
+    /// # Arguments
+    /// - `name` - Will be used for [serialization](#impl-Serialize-for-Activation<T>)
+    ///            and as the key in the static registry.
+    /// - `function` - The actual activation function.
+    /// - `derivative` - The derivative of `function`. (Needed for backpropagation.)
+    ///
+    /// # Returns
+    /// A new instance of `Activation<T>` with the provided values.
     pub fn new(name: impl Into<String>, function: TFunc<T>, derivative: TFunc<T>) -> Self {
         Self { name: name.into(), function, derivative }
     }

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -1,17 +1,17 @@
 //! Definition of the [`Activation`] struct and the most common activation functions as well as their
 //! derivatives.
 
-use std::collections::HashMap;
 use std::sync::RwLock;
 
-use generic_singleton::get_or_init;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::component::TensorComponent;
 use crate::tensor::TensorBase;
+use crate::utils::registry::Registry;
+
+pub use crate::utils::registered::Registered;
 
 
-type ActivationRegistry<T> = HashMap<String, Activation<T>>;
 type TFunc<T> = fn(&T) -> T;
 
 
@@ -32,9 +32,8 @@ pub struct Activation<T: TensorBase> {
 /// Methods for convenient construction and calling.
 impl<T: TensorBase> Activation<T> {
     /// Basic constructor.
-    pub fn new<S: Into<String>>(name: S, function: TFunc<T>, derivative: TFunc<T>) -> Self {
-        let name: String = name.into();
-        Self { name, function, derivative }
+    pub fn new(name: impl Into<String>, function: TFunc<T>, derivative: TFunc<T>) -> Self {
+        Self { name: name.into(), function, derivative }
     }
 
     /// Proxy for the actual activation function.
@@ -49,106 +48,55 @@ impl<T: TensorBase> Activation<T> {
 }
 
 
-/// Associated functions for registering and retrieving activation functions.
-///
-/// The activation registry is a singleton.
-/// It is static from the moment of initalization and generic over the [`TensorBase`] type.
-///
-/// # Implementation detail
-/// Under the hood the activation registry uses the **[`generic_singleton`]** crate
-/// to initialize and access a [`HashMap`] with the names as [`String`] keys and [`Activation`] values.
-///
-/// [`generic_singleton`]: https://docs.rs/generic_singleton/latest/generic_singleton/
-impl<T: TensorBase + 'static> Activation<T> {
-    /// Gets a static reference to the activation registry singleton.
-    /// The registry is wrapped in a [`RwLock`].
-    ///
-    /// When called for the first time, the activation registry is initialized first.
-    fn get_activation_registry() -> &'static RwLock<ActivationRegistry<T>> {
-        get_or_init!(|| {
-            let registry_lock = RwLock::new(ActivationRegistry::<T>::new());
-            Self::register_common(&registry_lock);
-            registry_lock
-        })
-    }
-
-    /// Registers reference implementations of some common activation functions.
-    ///
-    /// # Arguments
-    /// - `registry_lock` - Reference to the activation registry wrapped in a [`RwLock`]
-    fn register_common(registry_lock: &RwLock<ActivationRegistry<T>>) {
-        let mut registry = registry_lock.write().unwrap();
-        let _ = registry.insert(
-            "sigmoid".to_owned(),
-            Self::new("sigmoid".to_owned(), sigmoid, sigmoid_prime),
-        );
-        let _ = registry.insert(
-            "relu".to_owned(),
-            Self::new("relu".to_owned(), relu, relu_prime),
-        );
-    }
-
-    /// Creates and registers a new [`Activation`] with the specified parameters.
-    ///
-    /// The newly created `Activation` instance is added to the activation registry.
-    /// Subsequent calls to [`Activation::from_name`] passing the same name will return a clone of it.
-    ///
-    /// If an `Activation` was already registered under the specified `name`, it will be
-    /// replaced by the newly created one.
-    ///
-    /// # Arguments:
-    /// - `name` - Key under which to register the new activation;
-    ///            also passed on to the [`Activation::new`] constructor.
-    /// - `function` - Passed on to the [`Activation::new`] constructor.
-    /// - `derivative` - Passed on to the [`Activation::new`] constructor.
-    ///
-    /// # Returns
-    /// [`None`] if an activation with that name had not been registered before.
-    /// Otherwise the new `Activation` instance with the specified parameters is inserted and the old one is returned.
-    pub fn register<S: Into<String>>(name: S, function: TFunc<T>, derivative: TFunc<T>) -> Option<Self> {
-        let name: String = name.into();
-        let registry_lock = Self::get_activation_registry();
-        registry_lock.write().unwrap()
-                     .insert(name.clone(), Activation::new(name, function, derivative))
-    }
-
-    /// Retrieves a clone of a previously registered [`Activation`] by name.
-    ///
-    /// Reference implementations for the following activation functions are available by default:
-    /// - `sigmoid`
-    /// - `relu`
-    ///
-    /// A custom instance registered via [`Activation::register`] under one of those names will
-    /// replace the default implementation.
-    ///
-    ///
-    /// # Arguments
-    /// - `name` - The name/key of the activation to return.
-    ///
-    /// # Returns
-    /// Clone of the [`Activation`] instance with the specified `name` or [`None`] if none was
-    /// registered under that name.
-    pub fn from_name<S: Into<String>>(name: S) -> Option<Self> {
-        let registry_lock = Self::get_activation_registry();
-        registry_lock.read().unwrap()
-                     .get(&name.into())
-                     .and_then(|activation| Some(activation.clone()))
-    }
-}
-
-
 /// Allows [`serde`] to serialize [`Activation`] objects.
-impl<T: TensorBase> Serialize for Activation<T> {
+impl<T: 'static + TensorBase> Serialize for Activation<T> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&self.name)
+        Registered::serialize_as_key(self, serializer)
     }
 }
 
 
 /// Allows [`serde`] to deserialize to [`Activation`] objects.
-impl<'de, T: TensorBase + 'static> Deserialize<'de> for Activation<T> {
+impl<'de, T: 'static + TensorBase> Deserialize<'de> for Activation<T> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(Activation::from_name(String::deserialize(deserializer)?).unwrap())
+        Registered::deserialize_from_key(deserializer)
+    }
+}
+
+
+/// Provides a static registry of [`Activation<T>`] instances.
+///
+/// Reference implementations for the following functions (and their derivatives) are available by default:
+/// - `sigmoid`
+/// - `relu`
+///
+/// Custom instances registered via [`Registered::register`] under those names will replace the
+/// corresponding default implementations.
+///
+/// Registered instances can be retrieved by name via [`Registered::get`].
+///
+/// # Example
+/// ...
+impl<T: 'static + TensorBase> Registered<String> for Activation<T> {
+    /// Returns a reference to the name provided in the [`Activation::new`] constructor.
+    fn key(&self) -> &String {
+        &self.name
+    }
+
+    /// Registers reference implementations of some common activation functions (and their derivatives).
+    ///
+    /// This function should not be called directly. It is called once during initialization of the
+    /// [`Registered::Registry`] singleton for `Activation<T>`.
+    fn registry_post_init(registry_lock: &RwLock<Self::Registry>) {
+        let mut registry = registry_lock.write().unwrap();
+        let _ = registry.add(
+            "sigmoid".to_owned(),
+            Self::new("sigmoid".to_owned(), sigmoid, sigmoid_prime),
+        );
+        let _ = registry.add(
+            "relu".to_owned(),
+            Self::new("relu".to_owned(), relu, relu_prime),
+        );
     }
 }
 
@@ -238,35 +186,53 @@ mod tests {
 
             let name = "foo".to_owned();
 
-            let option = NDActivation::from_name("foo");
+            let option = NDActivation::get("foo");
             assert_eq!(option, None);
 
             // Register under that name for the first time.
-            let option = NDActivation::register(name.clone(), relu, relu_prime);
+            let option = NDActivation::new(name.clone(), relu, relu_prime).register();
             assert_eq!(option, None);
 
             // Get from registry by name.
-            let option = NDActivation::from_name("foo");
-            assert_eq!(option, Some(Activation { name: name.clone(), function: relu, derivative: relu_prime }));
+            let option = NDActivation::get("foo");
+            assert_eq!(
+                option,
+                Some(Activation { name: name.clone(), function: relu, derivative: relu_prime }),
+            );
 
             // Register different one under the same name. Should return the previous one.
-            let option = NDActivation::register(name.clone(), sigmoid, sigmoid_prime);
-            assert_eq!(option, Some(Activation { name: name.clone(), function: relu, derivative: relu_prime }));
+            let option = NDActivation::new(name.clone(), sigmoid, sigmoid_prime).register();
+            assert_eq!(
+                option,
+                Some(Activation { name: name.clone(), function: relu, derivative: relu_prime }),
+            );
 
             // Get the new one from the registry by name.
-            let option = NDActivation::from_name("foo");
-            assert_eq!(option, Some(Activation { name: name.clone(), function: sigmoid, derivative: sigmoid_prime }));
+            let option = NDActivation::get("foo");
+            assert_eq!(
+                option,
+                Some(Activation { name: name.clone(), function: sigmoid, derivative: sigmoid_prime }),
+            );
 
             // Get default `sigmoid` from the registry.
-            let option = NDActivation::from_name("sigmoid");
-            assert_eq!(option, Some(Activation { name: "sigmoid".to_owned(), function: sigmoid, derivative: sigmoid_prime }));
+            let option = NDActivation::get("sigmoid");
+            assert_eq!(
+                option,
+                Some(Activation { name: "sigmoid".to_owned(), function: sigmoid, derivative: sigmoid_prime }),
+            );
 
             // Replace it with a different `Activation` instance.
             fn identity<T: TensorBase>(t: &T) -> T { t.clone() }
-            let option = NDActivation::register("sigmoid", identity, identity);
-            assert_eq!(option, Some(Activation { name: "sigmoid".to_owned(), function: sigmoid, derivative: sigmoid_prime }));
-            let option = NDActivation::from_name("sigmoid");
-            assert_eq!(option, Some(Activation { name: "sigmoid".to_owned(), function: identity, derivative: identity }));
+            let option = NDActivation::new("sigmoid", identity, identity).register();
+            assert_eq!(
+                option,
+                Some(Activation { name: "sigmoid".to_owned(), function: sigmoid, derivative: sigmoid_prime }),
+            );
+            let option = NDActivation::get("sigmoid");
+            assert_eq!(
+                option,
+                Some(Activation { name: "sigmoid".to_owned(), function: identity, derivative: identity }),
+            );
         }
 
         #[test]

--- a/src/cost_function.rs
+++ b/src/cost_function.rs
@@ -1,10 +1,15 @@
-//! Definition of the [`CostFunction`] struct and the most common cost functions as well as their
-//! derivatives.
+//! Definition of the [`CostFunction`] struct and the most common cost functions.
+
+use std::sync::RwLock;
 
 use num_traits::ToPrimitive;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::tensor::{TensorBase, TensorOp};
+use crate::utils::registry::Registry;
+
+pub use crate::utils::registered::Registered;
+pub use self::functions::*;
 
 
 type TFunc<T> = fn(&T, &T) -> f32;
@@ -28,28 +33,8 @@ pub struct CostFunction<T: TensorBase> {
 /// Methods for convenient construction and calling.
 impl<T: TensorBase> CostFunction<T> {
     /// Basic constructor to manually define all fields.
-    pub fn new<S: Into<String>>(name: S, function: TFunc<T>, derivative: TFuncPrime<T>) -> Self {
+    pub fn new(name: impl Into<String>, function: TFunc<T>, derivative: TFuncPrime<T>) -> Self {
         Self { name: name.into(), function, derivative }
-    }
-
-    /// Convenience constructor for known/available cost functions.
-    ///
-    /// Pre-defined functions are determined from hard-coded names:
-    /// - [`quadratic`]
-    pub fn from_name<S, TO>(name: S) -> CostFunction<TO>
-    where
-        S:  Into<String>,
-        TO: TensorOp,
-    {
-        let name: String = name.into();
-        let function: TFunc<TO>;
-        let derivative: TFuncPrime<TO>;
-        if name == "quadratic" {
-            (function, derivative) = (quadratic, quadratic_prime);
-        } else {
-            panic!();
-        }
-        CostFunction { name, function, derivative }
     }
 
     /// Proxy for the actual cost function.
@@ -64,57 +49,117 @@ impl<T: TensorBase> CostFunction<T> {
 }
 
 
-impl<T: TensorOp> Default for CostFunction<T> {
+/// Returns an instance of the quadratic cost function as the default.
+impl<T: 'static + TensorOp> Default for CostFunction<T> {
     fn default() -> Self {
-        Self::from_name("quadratic")
+        Self::get("quadratic").unwrap()
     }
 }
 
 
 /// Allows [`serde`] to serialize [`CostFunction`] objects.
-impl<T: TensorBase> Serialize for CostFunction<T> {
+impl<T: 'static + TensorOp> Serialize for CostFunction<T> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&self.name)
+        Registered::serialize_as_key(self, serializer)
     }
 }
 
 
 /// Allows [`serde`] to deserialize to [`CostFunction`] objects.
-impl<'de, T: TensorOp> Deserialize<'de> for CostFunction<T> {
+impl<'de, T: 'static + TensorOp> Deserialize<'de> for CostFunction<T> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(Self::from_name(String::deserialize(deserializer)?))
+        Registered::deserialize_from_key(deserializer)
     }
 }
 
 
-/// Reference implementation of the quadratic cost function.
+/// Provides a static registry of [`CostFunction<T>`] instances.
 ///
-/// Calculated as the euclidian norm of the difference between actual and desired output divided by
-/// two.
-/// Used primarily during stochastic gradient descent.
+/// Reference implementations for some common functions (and their derivatives) are available by
+/// default under the following keys:
+/// - `quadratic` (see [`quadratic`] and [`quadratic_prime`])
 ///
-/// # Arguments
-/// * `output` - The actual output returned by a individual as a tensor.
-/// * `desired_output` - The desired output as a tensor.
+/// Custom instances registered via [`Registered::register`] under those names will replace the
+/// corresponding default implementations.
 ///
-/// # Returns
-/// The cost as 32 bit float.
-pub fn quadratic<T: TensorOp>(output: &T, desired_output: &T) -> f32 {
-    (desired_output - output).norm().to_f32().unwrap() / 2.
+/// Registered instances can be retrieved by name via [`Registered::get`].
+///
+/// # Example
+///
+/// ```rust
+/// use ndarray::{Array2, array};
+/// use num_traits::One;
+///
+/// use tensorevo::cost_function::{CostFunction, Registered};
+/// use tensorevo::tensor::TensorOp;
+///
+///
+/// fn main() {
+///     type T = Array2::<f32>;
+///
+///     // No cost function with the name `foo` was registered:
+///     assert_eq!(CostFunction::<T>::get("foo"), None);
+///
+///     // Common cost functions are available by default:
+///     let quadratic = CostFunction::<T>::get("quadratic").unwrap();
+///     let x = array![[1., 2.]];
+///     let y = array![[1., 0.]];
+///     assert_eq!(quadratic.call(&x, &y), 1.);
+///     assert_eq!(quadratic.call_derivative(&x, &y), array![[0., 2.]]);
+/// }
+/// ```
+impl<T: 'static + TensorOp> Registered<String> for CostFunction<T> {
+    /// Returns a reference to the name provided in the [`CostFunction::new`] constructor.
+    fn key(&self) -> &String {
+        &self.name
+    }
+
+    /// Registers reference implementations of some common cost functions (and their derivatives).
+    ///
+    /// This function should not be called directly. It is called once during initialization of the
+    /// [`Registered::Registry`] singleton for `CostFunction<T>`.
+    fn registry_post_init(registry_lock: &RwLock<Self::Registry>) {
+        let mut registry = registry_lock.write().unwrap();
+        let _ = registry.add(
+            "quadratic".to_owned(),
+            Self::new("quadratic".to_owned(), quadratic, quadratic_prime),
+        );
+    }
 }
 
+/// Reference implementations of some common cost functions as well as their derivatives.
+pub mod functions {
+    use super::*;
 
-/// Reference implementation of the derivative of the quadratic cost function.
-///
-/// Simply the difference between actual and desired output.
-/// Used only during stochastic gradient descent.
-///
-/// # Arguments
-/// * `output` - The actual output returned by a individual as a tensor.
-/// * `desired_output` - The desired output as a tensor.
-///
-/// # Returns
-/// Another tensor.
-pub fn quadratic_prime<T: TensorOp>(output: &T, desired_output: &T) -> T {
-    output - desired_output
+    /// Reference implementation of the quadratic cost function.
+    ///
+    /// Calculated as the euclidian norm of the difference between actual and desired output divided by
+    /// two.
+    /// Used primarily during stochastic gradient descent.
+    ///
+    /// # Arguments
+    /// * `output` - The actual output returned by a individual as a tensor.
+    /// * `desired_output` - The desired output as a tensor.
+    ///
+    /// # Returns
+    /// The cost as 32 bit float.
+    pub fn quadratic<T: TensorOp>(output: &T, desired_output: &T) -> f32 {
+        (desired_output - output).norm().to_f32().unwrap() / 2.
+    }
+
+
+    /// Reference implementation of the derivative of the quadratic cost function.
+    ///
+    /// Simply the difference between actual and desired output.
+    /// Used only during stochastic gradient descent.
+    ///
+    /// # Arguments
+    /// * `output` - The actual output returned by a individual as a tensor.
+    /// * `desired_output` - The desired output as a tensor.
+    ///
+    /// # Returns
+    /// Another tensor.
+    pub fn quadratic_prime<T: TensorOp>(output: &T, desired_output: &T) -> T {
+        output - desired_output
+    }
 }

--- a/src/cost_function.rs
+++ b/src/cost_function.rs
@@ -16,10 +16,12 @@ type TFunc<T> = fn(&T, &T) -> f32;
 type TFuncPrime<T> = fn(&T, &T) -> T;
 
 
-/// Convenience struct to store a cost function together with its name and derivative.
+/// Contains a named cost function together with its derivative.
 ///
-/// This is used in the [`Individual`] struct.
-/// Facilitates (de-)serialization.
+/// Used primarily in the [`Individual`] struct.
+///
+/// See the [**`Registerd`** trait implementation](#impl-Registered<String>-for-CostFunction<T>)
+/// below for a more general usage example.
 ///
 /// [`Individual`]: crate::individual::Individual
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -30,9 +32,18 @@ pub struct CostFunction<T: TensorBase> {
 }
 
 
-/// Methods for convenient construction and calling.
+/// Methods for construction and calling.
 impl<T: TensorBase> CostFunction<T> {
-    /// Basic constructor to manually define all fields.
+    /// Basic constructor.
+    ///
+    /// # Arguments
+    /// - `name` - Will be used for [serialization](#impl-Serialize-for-CostFunction<T>)
+    ///            and as the key in the static registry.
+    /// - `function` - The actual cost function.
+    /// - `derivative` - The derivative of `function`. (Needed for backpropagation.)
+    ///
+    /// # Returns
+    /// A new instance of `CostFunction<T>` with the provided values.
     pub fn new(name: impl Into<String>, function: TFunc<T>, derivative: TFuncPrime<T>) -> Self {
         Self { name: name.into(), function, derivative }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Rust library for creating, training and evolving neural networks.
 
-#![feature(iter_array_chunks, map_try_insert, trait_alias)]
+#![feature(associated_type_defaults, iter_array_chunks, map_try_insert, trait_alias)]
 
 pub mod activation;
 pub mod component;
@@ -9,4 +9,5 @@ pub mod individual;
 pub mod layer;
 pub mod population;
 pub mod tensor;
+pub mod utils;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,3 @@
+pub mod registered;
+pub mod registry;
+

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,5 @@
+//! Submodules containing some of the more abstract utilities.
+
 pub mod registered;
 pub mod registry;
 

--- a/src/utils/registered.rs
+++ b/src/utils/registered.rs
@@ -1,0 +1,176 @@
+//! Definition of the [`Registered`] trait.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use generic_singleton::get_or_init;
+use serde::{Deserializer, Serialize, Serializer};
+use serde::de::DeserializeOwned;
+
+use crate::utils::registry::{Registry, RegistryKey, RegistryValue};
+
+
+/// Add instances to a static [`Registry`] under an arbitrary key and retrieve them later.
+///
+/// The registry is a generic singleton. It is static from the moment of initialization and generic
+/// over the key type. This means that different key types will use different registries. Likewise,
+/// each type implementing [`Registered`] will have its own registry.
+///
+/// For a practical use case see [`Registered::serialize_as_key`] and [`Registered::deserialize_from_key`].
+///
+/// # Implementation detail
+/// Under the hood the registry uses the **[`generic_singleton`]** crate to initialize and access
+/// a [`Registry`] type ([`HashMap`] by default) with `K` type keys and `Self` type values.
+///
+/// [`generic_singleton`]: https://docs.rs/generic_singleton/latest/generic_singleton/
+pub trait Registered<K>: Clone + RegistryValue
+where
+    K: DeserializeOwned + RegistryKey + Serialize,
+{
+    /// Associated [`Registry`] type to use for storing instances of `Self`.
+    ///
+    /// [`HashMap<K, Self>`] by default.
+    type Registry: Registry<K, Self> = HashMap<K, Self>;
+
+    fn key(&self) -> &K;
+
+    /// Called by the default implementation of [`Registered::get_registry`] upon initialization.
+    ///
+    /// This means by default it will be called at most **once** for any `Registered<K>` type.
+    /// Can be used to e.g. automatically fill the registry with initial instances.
+    ///
+    /// # Arguments
+    /// - `registry_lock` - Associated registry singleton wrapped in a borrowed [`RwLock`].
+    #[allow(unused_variables)]
+    fn registry_post_init(registry_lock: &RwLock<Self::Registry>) {
+        ()
+    }
+
+    /// Returns a reference to the associated registry singleton.
+    ///
+    /// When called for the first time on a specific `Registry<K>` type, the associated
+    /// [`Registered::Registry`] is initialized and [`Registered::registry_post_init`] is called with it.
+    /// Repeated calls simply return the registry singleton.
+    ///
+    /// # Returns
+    /// Reference to the associated static registry singleton wrapped in a [`RwLock`].
+    fn get_registry() -> &'static RwLock<Self::Registry> { 
+        get_or_init!(|| { 
+            let registry_lock = RwLock::new(Self::Registry::default()); 
+            Self::registry_post_init(&registry_lock); 
+            registry_lock 
+        }) 
+    }
+
+    /// Adds a clone of the instance to the associated registry under the key returned by the
+    /// [`Registered::key`] implementation.
+    ///
+    /// Subsequent calls to [`Registered::get`] passing the instance's key will
+    /// return a clone of that instance.
+    ///
+    /// Initializes the associated registry singleton first, if necessary.
+    ///
+    /// # Returns
+    /// [`None`] if nothing was registered under the instance's key.
+    /// Otherwise the previous instance is replaced and returned.
+    fn register(&self) -> Option<Self> {
+        let registry_lock = Self::get_registry();
+        registry_lock.write().unwrap()
+                     .add(self.key().clone(), self.clone())
+    }
+
+    /// Retrieves a clone of a previously registered instance.
+    ///
+    /// Initializes the associated registry singleton first, if necessary.
+    ///
+    /// # Arguments
+    /// - `key` - Key under which the original instance was registered.
+    ///
+    /// # Returns
+    fn get(key: impl Into<K>) -> Option<Self> {
+        let registry_lock = Self::get_registry();
+        registry_lock.read().unwrap()
+                     .get_ref(&key.into())
+                     .and_then(|instance| Some(instance.clone()))
+    }
+
+    /// Convenience method for implementing [`serde::Serialize`] for types that implement
+    /// [`Registered`] such that instances are serialized through their keys.
+    ///
+    /// # Example
+    /// ```rust
+    /// use serde::{Serialize, Serializer};
+    /// use tensorevo::utils::registered::Registered;
+    ///
+    /// #[derive(Clone)]
+    /// struct NamedFunction {
+    ///     name: String,
+    ///     function: fn() -> f32,
+    /// }
+    ///
+    /// impl Registered<String> for NamedFunction {
+    ///     fn key(&self) -> &String {
+    ///         &self.name
+    ///     }
+    /// }
+    ///
+    /// impl Serialize for NamedFunction {
+    ///     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+    ///         Registered::serialize_as_key(self, serializer)
+    ///     }
+    /// }
+    ///
+    /// fn zero() -> f32 { 0. }
+    ///
+    /// fn main() {
+    ///     let named_zero = NamedFunction { name: "zero".to_owned(), function: zero };
+    ///     let serialized = serde_json::to_string(&named_zero).unwrap();
+    ///     assert_eq!(&serialized, "\"zero\"");
+    /// }
+    /// ```
+    fn serialize_as_key<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.key().serialize(serializer)
+    }
+
+    /// Convenience function for implementing [`serde::Deserialize`] for types that implement
+    /// [`Registered`] such that instances are deserialized from their names.
+    ///
+    /// # Example
+    /// ```rust
+    /// use serde::{Deserialize, Deserializer};
+    /// use tensorevo::utils::registered::Registered;
+    ///
+    /// #[derive(Clone, Debug, PartialEq)]
+    /// struct NamedFunction {
+    ///     name: String,
+    ///     function: fn() -> f32,
+    /// }
+    ///
+    /// impl Registered<String> for NamedFunction {
+    ///     fn key(&self) -> &String {
+    ///         &self.name
+    ///     }
+    /// }
+    ///
+    /// impl<'de> Deserialize<'de> for NamedFunction {
+    ///     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+    ///         Registered::deserialize_from_key(deserializer)
+    ///     }
+    /// }
+    ///
+    /// fn zero() -> f32 { 0. }
+    ///
+    /// fn main() {
+    ///     let named_zero = NamedFunction { name: "zero".to_owned(), function: zero };
+    ///     named_zero.register();
+    ///     let deserialized: NamedFunction = serde_json::from_str(" \"zero\" ").unwrap();
+    ///     assert_eq!(deserialized, named_zero);
+    /// }
+    /// ```
+    fn deserialize_from_key<'de, D>(deserializer: D) -> Result<Self, D::Error>
+    where D: Deserializer<'de>
+    {
+        Ok(Self::get(K::deserialize(deserializer)?).unwrap().clone())
+    }
+}
+

--- a/src/utils/registered.rs
+++ b/src/utils/registered.rs
@@ -84,12 +84,15 @@ where
     /// [`HashMap<K, Self>`] by default.
     type Registry: Registry<K, Self> = HashMap<K, Self>;
 
+    /// Returns the key (as a reference) under which the instance can be registered.
     fn key(&self) -> &K;
 
     /// Called by the default implementation of [`Registered::get_registry`] upon initialization.
     ///
     /// This means by default it will be called at most **once** for any `Registered<K>` type.
     /// Can be used to e.g. automatically fill the registry with initial instances.
+    ///
+    /// This function should not be called directly.
     ///
     /// # Arguments
     /// - `registry_lock` - Associated registry singleton wrapped in a borrowed [`RwLock`].
@@ -103,6 +106,9 @@ where
     /// When called for the first time on a specific `Registry<K>` type, the associated
     /// [`Registered::Registry`] is initialized and [`Registered::registry_post_init`] is called with it.
     /// Repeated calls simply return the registry singleton.
+    ///
+    /// This function should likely not be called directly.
+    /// Use [`Registered::register`] and [`Registered::get`] instead.
     ///
     /// # Returns
     /// Reference to the associated static registry singleton wrapped in a [`RwLock`].
@@ -139,6 +145,8 @@ where
     /// - `key` - Key under which the original instance was registered.
     ///
     /// # Returns
+    /// Clone of the instance with the specified `key` or [`None`] if none was registered under
+    /// that key.
     fn get(key: impl Into<K>) -> Option<Self> {
         let registry_lock = Self::get_registry();
         registry_lock.read().unwrap()

--- a/src/utils/registered.rs
+++ b/src/utils/registered.rs
@@ -92,7 +92,7 @@ where
     /// This means by default it will be called at most **once** for any `Registered<K>` type.
     /// Can be used to e.g. automatically fill the registry with initial instances.
     ///
-    /// This function should not be called directly.
+    /// This function should probably not be called directly.
     ///
     /// # Arguments
     /// - `registry_lock` - Associated registry singleton wrapped in a borrowed [`RwLock`].
@@ -107,7 +107,7 @@ where
     /// [`Registered::Registry`] is initialized and [`Registered::registry_post_init`] is called with it.
     /// Repeated calls simply return the registry singleton.
     ///
-    /// This function should likely not be called directly.
+    /// This function should probably not be called directly.
     /// Use [`Registered::register`] and [`Registered::get`] instead.
     ///
     /// # Returns

--- a/src/utils/registry.rs
+++ b/src/utils/registry.rs
@@ -53,12 +53,12 @@ where
 {
     /// Proxy for the [`HashMap::insert`] method.
     fn add(&mut self, key: K, value: V) -> Option<V> {
-        HashMap::<K, V>::insert(self, key, value)
+        self.insert(key, value)
     }
 
     /// Proxy for the [`HashMap::get`] method.
     fn get_ref(&self, key: &K) -> Option<&V> {
-        HashMap::<K, V>::get(&self, key)
+        self.get(key)
     }
 }
 

--- a/src/utils/registry.rs
+++ b/src/utils/registry.rs
@@ -1,0 +1,64 @@
+//! Definition of the [`Registry`] trait and related trait aliases.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+
+
+/// Trait alias for types that can be used as keys in a [`Registry`] type.
+pub trait RegistryKey = 'static + Clone + Eq + Hash + Send + Sync;
+
+/// Trait alias for types that can be used as values in a [`Registry`] type.
+pub trait RegistryValue = 'static + Send + Sync;
+
+
+/// Types that can function as a registry.
+///
+/// Add values under specific keys, potentially replacing older values and retrieve references to
+/// previously added values.
+pub trait Registry<K, V>: Default + Send + Sized + Sync
+where
+    K: RegistryKey,
+    V: RegistryValue,
+{
+    /// Adds a new key-value-pair to the `Registry` type instance.
+    ///
+    /// A reference to the `value` will be accessible via [`Registry::get_ref`] by passing `key`.
+    ///
+    /// # Arguments
+    /// - `key` - Key under which to store the `value` in the registry.
+    /// - `value` - Value to store in the registry under `key`.
+    ///
+    /// # Returns
+    /// [`None`] if nothing was previously added under the specified `key`.
+    /// Otherwise the previous value is replaced and returned.
+    fn add(&mut self, key: K, value: V) -> Option<V>;
+
+    /// Retrieves a reference to the value previously registered under `key`.
+    ///
+    /// # Arguments
+    /// - `key` - Key under which the original value was added to the registry.
+    ///
+    /// # Returns
+    /// Reference to the value stored in the registry under `key` or [`None`] if no value was
+    /// registered under the specified `key`.
+    fn get_ref(&self, key: &K) -> Option<&V>;
+}
+
+
+/// Trivial implementation of [`Registry`] for [`HashMap`].
+impl<K, V> Registry<K, V> for HashMap<K, V>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+{
+    /// Proxy for the [`HashMap::insert`] method.
+    fn add(&mut self, key: K, value: V) -> Option<V> {
+        HashMap::<K, V>::insert(self, key, value)
+    }
+
+    /// Proxy for the [`HashMap::get`] method.
+    fn get_ref(&self, key: &K) -> Option<&V> {
+        HashMap::<K, V>::get(&self, key)
+    }
+}
+

--- a/tests/test_sgd.rs
+++ b/tests/test_sgd.rs
@@ -1,6 +1,6 @@
 use ndarray::{Array2, array};
 
-use tensorevo::activation::Activation;
+use tensorevo::activation::{Activation, Registered};
 use tensorevo::cost_function::CostFunction;
 use tensorevo::individual::Individual;
 use tensorevo::layer::Layer;
@@ -18,7 +18,7 @@ fn test_sgd() {
                     [0.],
                     [0.],
                 ],
-                activation: Activation::from_name("relu").unwrap(),
+                activation: Activation::get("relu").unwrap(),
             },
             Layer{
                 weights: array![
@@ -29,7 +29,7 @@ fn test_sgd() {
                     [0.],
                     [0.],
                 ],
-                activation: Activation::from_name("relu").unwrap(),
+                activation: Activation::get("relu").unwrap(),
             },
         ],
         CostFunction::<Array2<f64>>::from_name("quadratic"),

--- a/tests/test_sgd.rs
+++ b/tests/test_sgd.rs
@@ -32,7 +32,7 @@ fn test_sgd() {
                 activation: Activation::get("relu").unwrap(),
             },
         ],
-        CostFunction::<Array2<f64>>::from_name("quadratic"),
+        CostFunction::<Array2<f64>>::get("quadratic").unwrap(),
     );
     let input1 = array![
         [1., 2.],


### PR DESCRIPTION
I tried to comprehensively document most of the new machinery, so it is probably easier to go through this after doing a `cargo doc --no-deps` first to have the rendered documentation at hand.

The "magic" happens in the `Registered` trait.

I added a new `utils` submodule and placed the new `Registry` and `Registered` traits there.

This breaks a few things. Mainly the `from_name` function is replaced by `get` for both `Activation` and `CostFunction` and it returns an `Option` depending on whether or not an instance with the specified name was registered before. A few trait bounds (mostly for `Serialize`/`Deserialize` implementations) are a bit stricter now because they now obviously rely on `T` being `'static`.