### PR TITLE
Implement `Fn` traits for `Activation`, `CostFunction`, `Layer` and `Individual`

### DIFF
--- a/src/activation.rs
+++ b/src/activation.rs
@@ -51,8 +51,8 @@ impl<T: TensorBase> Activation<T> {
     }
 
     /// Proxy for the derivative of the activation function.
-    pub fn d(&self, arg: &T) -> T {
-        (self.derivative)(arg)
+    pub fn d(&self, tensor: &T) -> T {
+        (self.derivative)(tensor)
     }
 }
 

--- a/src/cost_function.rs
+++ b/src/cost_function.rs
@@ -40,7 +40,10 @@ impl<T: TensorBase> CostFunction<T> {
     /// - `name` - Will be used for [serialization](#impl-Serialize-for-CostFunction<T>)
     ///            and as the key in the static registry.
     /// - `function` - The actual cost function.
+    ///                It should typically take the actual output of a calculation and the desired
+    ///                output for that same calculation as `TensorBase` types and return a float.
     /// - `derivative` - The derivative of `function`. (Needed for backpropagation.)
+    ///                  Unlike the cost function itself, this should return a `TensorBase` type.
     ///
     /// # Returns
     /// A new instance of `CostFunction<T>` with the provided values.
@@ -48,13 +51,8 @@ impl<T: TensorBase> CostFunction<T> {
         Self { name: name.into(), function, derivative }
     }
 
-    /// Proxy for the actual cost function.
-    pub fn call(&self, output: &T, desired_output: &T) -> f32 {
-        (self.function)(output, desired_output)
-    }
-
     /// Proxy for the derivative of the cost function.
-    pub fn call_derivative(&self, output: &T, desired_output: &T) -> T {
+    pub fn d(&self, output: &T, desired_output: &T) -> T {
         (self.derivative)(output, desired_output)
     }
 }
@@ -64,6 +62,68 @@ impl<T: TensorBase> CostFunction<T> {
 impl<T: 'static + TensorOp> Default for CostFunction<T> {
     fn default() -> Self {
         Self::get("quadratic").unwrap()
+    }
+}
+
+
+/// Makes `CostFunction<T>` callable by value (i.e. consuming the instance).
+///
+/// This is mainly implemented because [`FnOnce`] is a supertrait of [`Fn`].
+impl<T: TensorBase> FnOnce<(&T, &T)> for CostFunction<T> {
+    type Output = f32;
+
+    /// Proxy for the actual underlying cost function.
+    extern "rust-call" fn call_once(self, args: (&T, &T)) -> Self::Output {
+        (self.function)(args.0, args.1)
+    }
+}
+
+
+/// Makes `CostFunction<T>` callable by mutable reference.
+///
+/// This is mainly implemented because [`FnMut`] is a supertrait of [`Fn`].
+impl<T: TensorBase> FnMut<(&T, &T)> for CostFunction<T> {
+    /// Proxy for the actual underlying cost function.
+    extern "rust-call" fn call_mut(&mut self, args: (&T, &T)) -> Self::Output {
+        (self.function)(args.0, args.1)
+    }
+}
+
+
+/// Makes `CostFunction<T>` callable by immutable reference.
+///
+/// This allows you to use the call operator `( )` on instances and essentially treat them as functions.
+///
+/// # Example
+///
+/// ```rust
+/// use ndarray::array;
+/// use tensorevo::cost_function::CostFunction;
+/// use tensorevo::tensor::TensorBase;
+///
+/// fn zero_function<T: TensorBase>(_t1: &T, _t2: &T) -> f32 {
+///     0.
+/// }
+///
+/// fn zero_derivative<T: TensorBase>(t1: &T, _t2: &T) -> T {
+///     T::zeros(t1.shape())
+/// }
+///
+/// fn main() {
+///     let c = CostFunction::new("zero", zero_function, zero_derivative);
+///     let t1 = array![[1., 2.]];
+///     let t2 = array![[3., 4.]];
+///     let out = c(&t1, &t2);
+///     assert_eq!(out, 0.);
+/// }
+/// ```
+///
+/// The call operator always calls the actual cost function.
+/// To call the derivative use the [`CostFunction::d`] method.
+impl<T: TensorBase> Fn<(&T, &T)> for CostFunction<T> {
+    /// Proxy for the actual underlying cost function.
+    extern "rust-call" fn call(&self, args: (&T, &T)) -> Self::Output {
+        (self.function)(args.0, args.1)
     }
 }
 
@@ -115,8 +175,8 @@ impl<'de, T: 'static + TensorOp> Deserialize<'de> for CostFunction<T> {
 ///     let quadratic = CostFunction::<T>::get("quadratic").unwrap();
 ///     let x = array![[1., 2.]];
 ///     let y = array![[1., 0.]];
-///     assert_eq!(quadratic.call(&x, &y), 1.);
-///     assert_eq!(quadratic.call_derivative(&x, &y), array![[0., 2.]]);
+///     assert_eq!(quadratic(&x, &y), 1.);
+///     assert_eq!(quadratic.d(&x, &y), array![[0., 2.]]);
 /// }
 /// ```
 impl<T: 'static + TensorOp> Registered<String> for CostFunction<T> {
@@ -174,3 +234,83 @@ pub mod functions {
         output - desired_output
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use ndarray::{Array2, array};
+
+    use super::*;
+
+    mod test_cost_function {
+        use super::*;
+
+        #[test]
+        fn test_new() {
+            let cost_function = CostFunction::<Array2<f32>>::new(
+                "quadratic",
+                quadratic,
+                quadratic_prime,
+            );
+            assert_eq!(
+                cost_function,
+                CostFunction {
+                    name: "quadratic".to_owned(),
+                    function: quadratic,
+                    derivative: quadratic_prime,
+                },
+            );
+        }
+
+        #[test]
+        fn test_d() {
+            let actual_out  = array![[1., 2.]];
+            let desired_out = array![[1., 1.]];
+            let cost_func = CostFunction {
+                name: "quadratic".to_owned(),
+                function: quadratic,
+                derivative: quadratic_prime,
+            };
+            let cost = cost_func.d(&actual_out, &desired_out);
+            let expected_cost = array![[0., 1.]];
+            assert_eq!(cost, expected_cost);
+        }
+
+        #[test]
+        fn test_default() {
+            let default = CostFunction::<Array2<f32>>::default();
+            assert_eq!(
+                default,
+                CostFunction {
+                    name: "quadratic".to_owned(),
+                    function: quadratic,
+                    derivative: quadratic_prime,
+                },
+            );
+        }
+
+        #[test]
+        fn test_fn_traits() {
+            let actual_out  = array![[1., 2.]];
+            let desired_out = array![[1., 0.]];
+            let mut cost_func = CostFunction {
+                name: "quadratic".to_owned(),
+                function: quadratic,
+                derivative: quadratic_prime,
+            };
+            let expected_cost = 1.;
+
+            // Receiver borrowed:
+            let cost = cost_func(&actual_out, &desired_out);
+            assert_eq!(cost, expected_cost);
+
+            // Receiver mutably borrowed:
+            let cost = cost_func.call_mut((&actual_out, &desired_out));
+            assert_eq!(cost, expected_cost);
+
+            // Receiver moved:
+            let cost = cost_func.call_once((&actual_out, &desired_out));
+            assert_eq!(cost, expected_cost);
+        }
+    }
+}
+

--- a/src/individual.rs
+++ b/src/individual.rs
@@ -148,9 +148,9 @@ impl<T: Tensor> Individual<T> {
         // Activation of the last layer, i.e. the network's output:
         let output = activations.last().unwrap();
         // Derivative of the last layer's activation function with respect to its weighted input:
-        let activation_derivative = self.layers[num_layers - 1].activation.call_derivative(weighted_input);
+        let activation_derivative = self.layers[num_layers - 1].activation.d(weighted_input);
         // Derivative of the cost function with respect to the last layer's activation:
-        let cost_derivative = self.cost_function.call_derivative(output, desired_output);
+        let cost_derivative = self.cost_function.d(output, desired_output);
         // Delta of the last layer:
         let delta = cost_derivative * activation_derivative;
         // Calculate and add the last layer's gradient components first.
@@ -164,7 +164,7 @@ impl<T: Tensor> Individual<T> {
             // Activation of the previous layer:
             let previous_activation = if layer_num > 0 { &activations[layer_num - 1] } else { input };
             // Derivative of the layer's activation function with respect to its weighted input:
-            let activation_derivative = self.layers[layer_num].activation.call_derivative(weighted_input);
+            let activation_derivative = self.layers[layer_num].activation.d(weighted_input);
             // Delta of the layer:
             let delta = self.layers[layer_num + 1].weights.transpose().dot(&delta) * activation_derivative;
             // Calculate and add the layer's gradient components.
@@ -237,7 +237,7 @@ impl<T: Tensor> Individual<T> {
     /// # Returns
     /// The error value
     pub fn calculate_error(&self, input: &T, desired_output: &T) -> f32 {
-        self.cost_function.call(&self.forward_pass(input), desired_output)
+        (self.cost_function)(&self.forward_pass(input), desired_output)
     }
 }
 

--- a/src/individual.rs
+++ b/src/individual.rs
@@ -21,8 +21,8 @@ use crate::cost_function::CostFunction;
 
 /// Neural network with evolutionary methods.
 ///
-/// Derives the [`Deserialize`] and [`Serialize`] traits from [`serde`],
-/// as well as [`PartialEq`] and [`Debug`].
+/// Can be called as a function to feed forward an input through the entire network.
+/// (See [`Fn` implementation](#impl-Fn<(%26T,)>-for-Individual<T>) below.)
 #[derive(Clone, Deserialize, Serialize, PartialEq, Debug)]
 #[serde(bound = "")]
 pub struct Individual<T: Tensor> {
@@ -66,10 +66,6 @@ impl<T: Tensor> Individual<T> {
         }
     }
 
-    pub fn id(&self) -> u128 {
-        self.id
-    }
-
     /// Load an individual from a json file
     /// 
     /// # Arguments
@@ -81,19 +77,14 @@ impl<T: Tensor> Individual<T> {
         Ok(serde_json::from_str(read_to_string(path)?.as_str())?)
     }
 
-    pub fn num_layers(&self) -> usize {
-        self.layers.len()
+    /// Returns the unique identifier of the `Individual` instance.
+    pub fn id(&self) -> u128 {
+        self.id
     }
 
-    /// Performs a full forward pass for a given input and returns the network's output.
-    ///
-    /// # Arguments
-    /// * `input` - [Tensor] with a shape that matches the first/input layer
-    ///
-    /// # Returns
-    /// Output tensor from the last layer
-    pub fn forward_pass(&self, input: &T) -> T {
-        self.layers.iter().fold(input.clone(), |output, layer| layer.feed_forward(&output).1)
+    /// Returns the number of layers (**not** including the input layer) in the network.
+    pub fn num_layers(&self) -> usize {
+        self.layers.len()
     }
 
     /// Passes the `input` through the network and returns the intermediate results of each layer.
@@ -237,9 +228,94 @@ impl<T: Tensor> Individual<T> {
     /// # Returns
     /// The error value
     pub fn calculate_error(&self, input: &T, desired_output: &T) -> f32 {
-        (self.cost_function)(&self.forward_pass(input), desired_output)
+        (self.cost_function)(&self(input), desired_output)
     }
 }
+
+
+/// Makes `Individual<T>` callable by value (i.e. consuming the instance).
+///
+/// This is mainly implemented because [`FnOnce`] is a supertrait of [`Fn`].
+/// (See [`Individual::call`].)
+impl<T: Tensor> FnOnce<(&T,)> for Individual<T> {
+    type Output = T;
+
+    /// See [`Individual::call`].
+    extern "rust-call" fn call_once(self, args: (&T,)) -> Self::Output {
+        self.layers.iter().fold(args.0.clone(), |output, layer| layer(&output))
+    }
+}
+
+
+/// Makes `Individual<T>` callable by mutable reference.
+///
+/// This is mainly implemented because [`FnMut`] is a supertrait of [`Fn`].
+/// (See [`Individual::call`].)
+impl<T: Tensor> FnMut<(&T,)> for Individual<T> {
+    /// See [`Individual::call`].
+    extern "rust-call" fn call_mut(&mut self, args: (&T,)) -> Self::Output {
+        self.layers.iter().fold(args.0.clone(), |output, layer| layer(&output))
+    }
+}
+
+
+/// Makes `Individual<T>` callable by immutable reference.
+///
+/// This allows you to use the call operator `( )` on instances and essentially treat them as functions.
+///
+/// # Example
+///
+/// ```rust
+/// use ndarray::array;
+/// use tensorevo::activation::{Activation, Registered};
+/// use tensorevo::cost_function::CostFunction;
+/// use tensorevo::individual::Individual;
+/// use tensorevo::layer::Layer;
+///
+/// fn main() {
+///     // Simply doubles the input and subtracts 1 in the first component.
+///     let individual = Individual::new(
+///         vec![
+///             Layer {
+///                 weights: array![
+///                     [2., 0.],
+///                     [0., 2.],
+///                 ],
+///                 biases: array![
+///                     [-1.],
+///                     [ 0.],
+///                 ],
+///                 activation: Activation::get("identity").unwrap(),
+///             },
+///         ],
+///         CostFunction::default(),
+///     );
+///
+///     let input = array![
+///         [ 2.],
+///         [-2.],
+///     ];
+///     let expected_output = array![
+///         [ 3.],
+///         [-4.],
+///     ];
+///     let output = individual(&input);
+///     assert_eq!(output, expected_output);
+/// }
+/// ```
+impl<T: Tensor> Fn<(&T,)> for Individual<T> {
+    /// Performs a full forward pass for a given input and returns the network's output.
+    ///
+    /// # Arguments
+    /// * `input` - [Tensor] with a shape that matches the input layer.
+    ///
+    /// # Returns
+    /// Output tensor returned from the last layer
+    extern "rust-call" fn call(&self, args: (&T,)) -> Self::Output {
+        self.layers.iter().fold(args.0.clone(), |output, layer| layer(&output))
+    }
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/src/individual.rs
+++ b/src/individual.rs
@@ -325,8 +325,8 @@ mod tests {
     use ndarray::array;
     use tempfile::NamedTempFile;
 
-    use crate::activation::{Activation, sigmoid, sigmoid_prime, relu, relu_prime};
-    use crate::cost_function::{CostFunction, quadratic, quadratic_prime};
+    use crate::activation::{Activation, Registered};
+    use crate::cost_function::CostFunction;
 
     #[test]
     fn test_from_file() -> Result<(), LoadError> {
@@ -334,13 +334,13 @@ mod tests {
             "id": 0,
             "layers": [
                 {
-                    "weights":    {"v": 1, "dim": [2,2], "data": [0.0,1.0,2.0,3.0]},
-                    "biases":     {"v": 1, "dim": [2,1], "data": [4.0,5.0]},
+                    "weights":    {"v": 1, "dim": [2, 2], "data": [0.0, 1.0, 2.0, 3.0]},
+                    "biases":     {"v": 1, "dim": [2, 1], "data": [4.0, 5.0]},
                     "activation": "sigmoid"
                 },
                 {
-                    "weights":    {"v": 1, "dim": [2,2], "data": [0.0,-1.0,-2.0,-3.0]},
-                    "biases":     {"v": 1, "dim": [2,1], "data": [-4.0,-5.0]},
+                    "weights":    {"v": 1, "dim": [2, 2], "data": [0.0, -1.0, -2.0, -3.0]},
+                    "biases":     {"v": 1, "dim": [2, 1], "data": [-4.0, -5.0]},
                     "activation": "relu"
                 }
             ]
@@ -351,15 +351,15 @@ mod tests {
                 Layer::new(
                     array![[0., 1.], [2., 3.]],
                     array![[4.], [5.]],
-                    Activation::new("sigmoid", sigmoid, sigmoid_prime),
+                    Activation::get("sigmoid").unwrap(),
                 ),
                 Layer::new(
                     array![[0., -1.], [-2., -3.]],
                     array![[-4.], [-5.]],
-                    Activation::new("relu", relu, relu_prime),
+                    Activation::get("relu").unwrap(),
                 ),
             ],
-            cost_function: CostFunction::new("quadratic", quadratic, quadratic_prime),
+            cost_function: CostFunction::default(),
         };
         let mut individual_file = NamedTempFile::new()?;
         individual_file.write_all(individual_json.as_bytes())?;

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -22,7 +22,7 @@ impl<T: Tensor> Layer<T> {
 
     pub fn feed_forward(&self, input: &T) -> (T, T) {
         let weighted_input = &self.weights.dot(input) + &self.biases;
-        let activation = self.activation.call(&weighted_input);
+        let activation = (self.activation)(&weighted_input);
         (weighted_input, activation)
     }
 }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -27,13 +27,89 @@ impl<T: Tensor> Layer<T> {
     }
 }
 
+
+impl<T: Tensor> FnOnce<(&T,)> for Layer<T> {
+    type Output = T;
+
+    extern "rust-call" fn call_once(self, args: (&T,)) -> Self::Output {
+        self.feed_forward(args.0).1
+    }
+}
+
+
+impl<T: Tensor> FnMut<(&T,)> for Layer<T> {
+    extern "rust-call" fn call_mut(&mut self, args: (&T,)) -> Self::Output {
+        self.feed_forward(args.0).1
+    }
+}
+
+
+impl<T: Tensor> Fn<(&T,)> for Layer<T> {
+    extern "rust-call" fn call(&self, args: (&T,)) -> Self::Output {
+        self.feed_forward(args.0).1
+    }
+}
+
+
 #[cfg(test)]
 mod tests {
-    use ndarray::array;
+    use ndarray::{Array2, array};
+    use num_traits::One;
 
     use super::*;
 
+    fn double<T: Tensor>(t: &T) -> T {
+        t + t
+    }
+
+    fn twos<T: Tensor>(t: &T) -> T {
+        let ones = T::from_num(T::Component::one(), t.shape());
+        &ones + &ones
+    }
+
     #[test]
-    fn test() {
-    }    
+    fn test_new() {
+        let weights = array![[1., 0.], [0., 1.]];
+        let biases = array![[0.], [0.]];
+        let activation = Activation::new("double", double, twos);
+
+        let layer = Layer::<Array2<f32>>::new(weights.clone(), biases.clone(), activation.clone());
+        assert_eq!(layer, Layer { weights, biases, activation });
+    }
+
+    #[test]
+    fn test_feed_forward() {
+        let weights = array![[1., 0.], [0., 1.]];
+        let biases = array![[1.], [1.]];
+        let activation = Activation::new("double", double, twos);
+        let layer = Layer { weights, biases, activation };
+
+        let input = array![[0.], [42.]];
+        let (weighted_input, output) = layer.feed_forward(&input);
+        assert_eq!(weighted_input, array![[1.], [43.]]);
+        assert_eq!(output, array![[2.], [86.]]);
+    }
+
+    # [test]
+    fn test_fn_traits() {
+        let weights = array![[1., 0.], [0., 1.]];
+        let biases = array![[1.], [1.]];
+        let activation = Activation::new("double", double, twos);
+        let mut layer = Layer { weights, biases, activation };
+
+        let input = array![[0.], [1.]];
+        let expected_output = array![[2.], [4.]];
+
+        // Receiver borrowed:
+        let output = layer(&input);
+        assert_eq!(output, expected_output);
+
+        // Receiver mutably borrowed:
+        let output = layer.call_mut((&input,));
+        assert_eq!(output, expected_output);
+
+        // Receiver moved:
+        let output = layer.call_once((&input,));
+        assert_eq!(output, expected_output);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Rust library for creating, training and evolving neural networks.
 
-#![feature(associated_type_defaults, iter_array_chunks, map_try_insert, trait_alias)]
+#![feature(associated_type_defaults, fn_traits, iter_array_chunks, map_try_insert, trait_alias, unboxed_closures)]
 
 pub mod activation;
 pub mod component;


### PR DESCRIPTION
Making `Activation`, `CostFunction`, `Layer` and `Individual` all **callable** as functions makes sense semantically and improves their ergonomics. Instances of all of them are functions in the mathematical sense and calling those functions via
`activation(&tensor)` rather than `activation.call(&tensor)` or
`individual(&input)` instead of `individual.feed_forward(&input)`
is just much nicer.

Since [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html) is sub-trait of `FnMut` and `FnOnce`, those were obviously implemented as well, and the documentation I wrote for those merely points to the respective `Fn` implementations.

The manual implementation of the `Fn` traits is still unstable behind the `fn_traits` and `unboxed_closures` feature gates, but since we are already on the _nightly_ train, we may as well get comfortable. All of this is experimental anyway.

### `Activation` and `CostFunction`

- Replace `call` method with `Fn::call`.
- Rename `call_derivative` to `d`.
- Add a pre-registered `identity` activation function, mainly for convenient testing.

### `Layer`

- Keep the `feed_forward` method because it returns both the weighted-and-biased input _and_ the activation.
- Make the `Fn::call` implementation just call `feed_forward` and discard the first element of the 2-tuple.

### `Individual`

- Replace `forward_pass` method with `Fn::call`.
- Have that `call` method still `fold` the input "through the layers", but now with the much nicer call-operator for each layer.